### PR TITLE
Fix: allow localhost/127.0.0.1 in TrustedHostMiddleware to stop “Invalid host header”

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ CSRF_SECRET=changeme_csrf_secret
 # Example: http://localhost:3000. Blank -> blocks external requests.
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 
+# [任意 Optional] 許可するホスト / Comma-separated list of allowed hosts.
+# Defaults: 127.0.0.1,localhost,127.0.0.1:8001,localhost:8001
+ALLOWED_HOSTS=127.0.0.1,localhost,127.0.0.1:8001,localhost:8001
+
 # [任意 Optional] レート制限 / Request rate limit per client.
 # Format: N/period (e.g., 5/minute). Blank -> unlimited (not recommended).
 RATE_LIMIT=5/minute

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,2 @@
+## Unreleased
+- Fix Invalid host header when running locally

--- a/main.py
+++ b/main.py
@@ -24,7 +24,6 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response, UploadFi
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from urllib.parse import urlparse
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from fastapi.responses import FileResponse, JSONResponse
 from jose import JWTError, jwt
@@ -83,7 +82,10 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"]
 )
-allowed_hosts = [urlparse(o).netloc or o for o in origins] or ["localhost"]
+allowed_hosts = [h.strip() for h in os.getenv(
+    "ALLOWED_HOSTS",
+    "127.0.0.1,localhost,127.0.0.1:8001,localhost:8001",
+).split(",") if h.strip()]
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=allowed_hosts)
 
 # --- Rate Limiting ---

--- a/tests/e2e/test_app.py
+++ b/tests/e2e/test_app.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 os.environ.setdefault("CSRF_SECRET_SALT", "test_salt")
 os.environ.setdefault("CORS_ALLOWED_ORIGINS", "http://testserver")
+os.environ.setdefault("ALLOWED_HOSTS", "testserver")
 from main import app
 
 client = TestClient(app)


### PR DESCRIPTION
### Why
Running the FastAPI server locally (`uvicorn main:app`) returned *Invalid host header*
because the default `TrustedHostMiddleware` list didn’t include ports or localhost.

### What
* Read `ALLOWED_HOSTS` from **.env** (with sensible defaults)
* Updated `.env.example` so newcomers don’t hit the issue
* Added release note to `CHANGELOG.md`

### How to test
```bash
uvicorn main:app --reload --port 8001
# → open http://127.0.0.1:8001/docs  ✅
```

Closes #<issue-number>


------
https://chatgpt.com/codex/tasks/task_e_68908c4365048322b37b6677fdc08f64