### PR TITLE
fix(security): path traversal, csrf and host validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ JWT_EXPIRE_SECONDS=3600
 
 # [必須 Required] CSRF対策用シークレット / Secret for CSRF token.
 # Generate random string (32 chars). Blank -> CSRF protection disabled.
-CSRF_SECRET=changeme_csrf_secret
+CSRF_SECRET_SALT=changeme_csrf_secret
 
 # [Optional] Disable CSRF protection for local development on Windows.
 # CSRF_DISABLE=true
@@ -41,7 +41,7 @@ CSRF_SECRET=changeme_csrf_secret
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # [任意 Optional] 許可するホスト / Comma-separated list of allowed hosts.
-# ALLOWED_HOSTS=127.0.0.1,localhost
+ALLOWED_HOSTS=127.0.0.1,localhost,127.0.0.1:8001,localhost:8001
 
 # [任意 Optional] レート制限 / Request rate limit per client.
 # Format: N/period (e.g., 5/minute). Blank -> unlimited (not recommended).

--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ curl -OJ -H "Authorization: Bearer <TOKEN>" \\
 
 ## Windows Quick-Start Troubleshooting / Windows クイックスタートトラブルシューティング
 - Install `bcrypt==4.0.1` to avoid passlib conflicts / `passlib` の衝突を避けるため `bcrypt==4.0.1` をインストールしてください。
+- Set `CSRF_SECRET_SALT` in `.env` to enable CSRF protection / `.env` に `CSRF_SECRET_SALT` を設定して CSRF を有効化します。
 - During local development set `CSRF_DISABLE=true` in `.env` to bypass CSRF on docs / ローカル開発時は `.env` に `CSRF_DISABLE=true` を設定してドキュメントの CSRF を無効化します。
+- Adjust `ALLOWED_HOSTS` if accessing the API via a different host or port / 別ホストやポートでアクセスする場合は `ALLOWED_HOSTS` を調整してください。
 - Save `.env` in UTF-8 without BOM to prevent `UnicodeDecodeError` / `.env` は UTF-8 (BOM なし) で保存し、`UnicodeDecodeError` を防止してください。
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,2 +1,2 @@
 ## Unreleased
-- Fix invalid host header when running locally by enforcing TrustedHostMiddleware
+- Harden download endpoints against path traversal; enable real CSRF validation; fix allowed hosts; deduplicate UserManager

--- a/tests/e2e/test_app.py
+++ b/tests/e2e/test_app.py
@@ -8,15 +8,18 @@ from fastapi.testclient import TestClient
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 os.environ.setdefault("CSRF_SECRET_SALT", "test_salt")
 os.environ.setdefault("CORS_ALLOWED_ORIGINS", "http://localhost")
+os.environ.setdefault("CSRF_DISABLE", "true")
 from main import app
 
 client = TestClient(app, base_url="http://localhost")
+
 
 @pytest.fixture(scope="session")
 def token() -> str:
     client.post("/auth/signup", json={"username": "u", "password": "p"})
     res = client.post("/auth/token", data={"username": "u", "password": "p"})
     return res.json()["access_token"]
+
 
 @pytest.fixture(scope="session")
 def session_id(token: str) -> str:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,54 @@
+import importlib
+import os
+from fastapi.testclient import TestClient
+from fastapi import Request
+
+from users.deps import get_user_manager
+
+
+def load_app(**env):
+    os.environ.setdefault("CSRF_SECRET_SALT", "test_salt")
+    for k, v in env.items():
+        os.environ[k] = v
+    import main
+
+    importlib.reload(main)
+    return main
+
+
+def test_path_traversal_blocked():
+    main = load_app(CSRF_DISABLE="true")
+    client = TestClient(main.app, base_url="http://localhost")
+    client.post("/auth/signup", json={"username": "u", "password": "p"})
+    res = client.post("/auth/token", data={"username": "u", "password": "p"})
+    token = res.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.get("/api/download/%2e%2e/%2e%2e/.env", headers=headers)
+    assert resp.status_code == 403
+
+
+def test_csrf_env_match():
+    main = load_app(CSRF_DISABLE="true")
+    assert main.CsrfSettings().secret_key == os.environ["CSRF_SECRET_SALT"]
+    request = Request({"type": "http", "app": main.app})
+    um = get_user_manager(request)
+    assert id(um) == id(main.app.state.user_manager)
+
+
+def test_csrf_validation():
+    main = load_app(CSRF_DISABLE="false")
+    client = TestClient(
+        main.app, base_url="http://localhost", raise_server_exceptions=False
+    )
+    res = client.post("/users/signup", json={"username": "a", "password": "b"})
+    assert res.status_code == 403
+
+
+def test_allowed_hosts():
+    main = load_app(
+        CSRF_DISABLE="true",
+        ALLOWED_HOSTS="127.0.0.1,localhost,127.0.0.1:8001,localhost:8001",
+    )
+    client = TestClient(main.app, base_url="http://127.0.0.1:8001")
+    resp = client.get("/docs")
+    assert resp.status_code == 200

--- a/users/deps.py
+++ b/users/deps.py
@@ -1,0 +1,7 @@
+from fastapi import Request
+
+from .auth import UserManager
+
+
+def get_user_manager(request: Request) -> UserManager:
+    return request.app.state.user_manager


### PR DESCRIPTION
## Summary
- harden file download endpoints against path traversal
- enforce CSRF validation with unified configuration
- validate trusted hosts and reuse a single UserManager

## Testing
- `black --check main.py api.py auth/router.py users/deps.py tests/e2e/test_app.py tests/test_security.py`
- `ruff check main.py api.py auth/router.py users/deps.py tests/e2e/test_app.py tests/test_security.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890bc9da360832286a540d1a0992378