### PR TITLE
Add web browsing and file operation tools with executor

### DIFF
--- a/orallm/__init__.py
+++ b/orallm/__init__.py
@@ -1,0 +1,1 @@
+"""ORALLM package."""

--- a/orallm/agent/__init__.py
+++ b/orallm/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Agent package providing planning and execution utilities."""

--- a/orallm/agent/executor.py
+++ b/orallm/agent/executor.py
@@ -1,0 +1,44 @@
+"""Execution engine for running plans."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from .tools import web_browse, file_ops
+
+logger = logging.getLogger(__name__)
+
+TOOLS = {
+    "web_browse": web_browse.search,
+    "file_ops": file_ops.handle,
+}
+
+
+def run_plan(plan: List[Dict[str, Any]]) -> List[Any]:
+    """Execute a plan composed of tool actions.
+
+    Parameters
+    ----------
+    plan:
+        List of steps.  Each step is a mapping with the keys ``"tool"``
+        and ``"args"`` describing which tool to invoke and the keyword
+        arguments for that tool.
+
+    Returns
+    -------
+    list[Any]
+        Results returned from each tool invocation.
+    """
+    results: List[Any] = []
+    for idx, step in enumerate(plan, start=1):
+        tool_name = step.get("tool")
+        args = step.get("args", {})
+        func = TOOLS.get(tool_name)
+        if func is None:
+            logger.error("Unknown tool: %s", tool_name)
+            raise ValueError(f"Unknown tool: {tool_name}")
+        logger.info("Step %d: executing %s with args %s", idx, tool_name, args)
+        result = func(**args)
+        logger.debug("Step %d result: %r", idx, result)
+        results.append(result)
+    return results

--- a/orallm/agent/llm.py
+++ b/orallm/agent/llm.py
@@ -1,0 +1,34 @@
+"""Interface with a local Ollama large language model."""
+from __future__ import annotations
+
+from typing import Any
+import requests
+
+
+def generate(prompt: str, model: str = "llama2", **kwargs: Any) -> str:
+    """Generate text using a local Ollama server.
+
+    Parameters
+    ----------
+    prompt:
+        Prompt text to send to the model.
+    model:
+        Name of the model to use. Defaults to ``"llama2"``.
+    **kwargs:
+        Additional parameters forwarded to the API.
+
+    Returns
+    -------
+    str
+        The generated text returned by the model.  An empty string is
+        returned if the request fails.
+    """
+    url = "http://localhost:11434/api/generate"
+    payload = {"model": model, "prompt": prompt, "stream": False, **kwargs}
+    try:
+        response = requests.post(url, json=payload, timeout=60)
+        response.raise_for_status()
+    except Exception:
+        return ""
+    data = response.json()
+    return data.get("response", "")

--- a/orallm/agent/planner.py
+++ b/orallm/agent/planner.py
@@ -1,0 +1,25 @@
+"""Simple planner that produces a list of tool invocations."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def make_plan(goal: str) -> List[Dict[str, Any]]:
+    """Create a simple plan based on the provided goal.
+
+    The current implementation is intentionally naive and is primarily
+    intended for unit testing.  It returns a single step instructing the
+    agent to perform a web search using the goal as the query.
+
+    Parameters
+    ----------
+    goal:
+        The user's objective.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        A list of plan steps.  Each step contains a ``tool`` name and the
+        keyword arguments to pass to that tool.
+    """
+    return [{"tool": "web_browse", "args": {"query": goal}}]

--- a/orallm/agent/tools/__init__.py
+++ b/orallm/agent/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Utility tools available to the agent."""
+from __future__ import annotations
+
+from . import web_browse, file_ops
+
+__all__ = ["web_browse", "file_ops"]

--- a/orallm/agent/tools/file_ops.py
+++ b/orallm/agent/tools/file_ops.py
@@ -1,0 +1,55 @@
+"""Local text file operations."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def handle(action: str, path: str, text: Optional[str] = None) -> str:
+    """Handle basic text file operations.
+
+    Parameters
+    ----------
+    action:
+        Operation to perform: ``"read"``, ``"append"``, or ``"write"``.
+    path:
+        Path to the target file.
+    text:
+        Text to append or write. Required for ``"append"`` and ``"write"``.
+
+    Returns
+    -------
+    str
+        File contents for ``"read"`` or a confirmation message for other
+        operations.
+    """
+    if action == "read":
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read()
+            logger.info("Read %d bytes from %s", len(content), path)
+            return content
+        except FileNotFoundError:
+            logger.warning("File not found: %s", path)
+            return ""
+
+    if action == "append":
+        if text is None:
+            raise ValueError("append action requires text")
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(text)
+        logger.info("Appended %d bytes to %s", len(text), path)
+        return "append ok"
+
+    if action in {"write", "overwrite"}:
+        if text is None:
+            raise ValueError("write action requires text")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        logger.info("Wrote %d bytes to %s", len(text), path)
+        return "write ok"
+
+    logger.error("Unknown file action: %s", action)
+    raise ValueError(f"Unknown action: {action}")

--- a/orallm/agent/tools/web_browse.py
+++ b/orallm/agent/tools/web_browse.py
@@ -1,0 +1,43 @@
+"""Web browsing utilities using DuckDuckGo."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def search(query: str) -> str:
+    """Search the web using DuckDuckGo.
+
+    Parameters
+    ----------
+    query:
+        Search query string.
+
+    Returns
+    -------
+    str
+        A short snippet from the first search result if available, otherwise
+        an empty string.
+    """
+    url = "https://api.duckduckgo.com/"
+    params = {"q": query, "format": "json", "no_redirect": 1, "no_html": 1}
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.exception("DuckDuckGo search failed: %s", exc)
+        return ""
+
+    if data.get("AbstractText"):
+        return data["AbstractText"]
+    topics = data.get("RelatedTopics")
+    if isinstance(topics, list) and topics:
+        first = topics[0]
+        if isinstance(first, dict) and "Text" in first:
+            return str(first["Text"])
+    return ""

--- a/orallm/api/main.py
+++ b/orallm/api/main.py
@@ -1,0 +1,16 @@
+"""FastAPI application exposing the agent."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from ..agent import planner, executor
+
+app = FastAPI()
+
+
+@app.post("/run")
+async def run(goal: str) -> dict:
+    """Create a plan for ``goal`` and execute it."""
+    plan = planner.make_plan(goal)
+    results = executor.run_plan(plan)
+    return {"plan": plan, "results": results}

--- a/tests/test_executor_run_plan.py
+++ b/tests/test_executor_run_plan.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from orallm.agent import executor
+
+
+def test_run_plan_executes_steps(tmp_path, monkeypatch):
+    out_file = tmp_path / "out.txt"
+
+    def fake_search(query: str) -> str:
+        return "result for " + query
+
+    monkeypatch.setitem(executor.TOOLS, "web_browse", fake_search)
+
+    plan = [
+        {"tool": "web_browse", "args": {"query": "python"}},
+        {
+            "tool": "file_ops",
+            "args": {"action": "write", "path": str(out_file), "text": "data"},
+        },
+        {"tool": "file_ops", "args": {"action": "read", "path": str(out_file)}},
+    ]
+
+    results = executor.run_plan(plan)
+    assert results[0] == "result for python"
+    assert results[1] == "write ok"
+    assert results[2] == "data"
+    assert out_file.read_text() == "data"

--- a/tests/test_orallm_tools.py
+++ b/tests/test_orallm_tools.py
@@ -1,0 +1,27 @@
+from orallm.agent.tools import web_browse, file_ops
+
+
+def test_web_browse_search(monkeypatch):
+    def fake_get(url, params, timeout):
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"AbstractText": "OpenAI creates AI"}
+
+        return FakeResponse()
+
+    monkeypatch.setattr(web_browse.requests, "get", fake_get)
+    result = web_browse.search("openai")
+    assert result == "OpenAI creates AI"
+
+
+def test_file_ops_handle(tmp_path):
+    file_path = tmp_path / "demo.txt"
+    write_res = file_ops.handle("write", str(file_path), "hello")
+    assert write_res == "write ok"
+    append_res = file_ops.handle("append", str(file_path), " world")
+    assert append_res == "append ok"
+    read_res = file_ops.handle("read", str(file_path))
+    assert read_res == "hello world"


### PR DESCRIPTION
## Summary
- implement DuckDuckGo web search tool
- support reading and writing local files
- execute plans via executor
- provide FastAPI endpoint and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68924709c8788322b854c40b81877fe4